### PR TITLE
Remove unnecessary bindings with better-monadic-for

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -4,6 +4,7 @@ import mill.contrib.scalapblib._
 
 trait ScalaSettingsModule extends ScalaModule {
   def scalaVersion = "2.12.7"
+  def scalacPluginIvyDeps = Agg(ivy"com.olegpy::better-monadic-for:0.3.0-M4")
   def scalacOptions = Seq(
     // Common options
     "-deprecation",                      // Emit warning and location for usages of deprecated APIs.

--- a/codegen/src/inc/codegen/Codegen.scala
+++ b/codegen/src/inc/codegen/Codegen.scala
@@ -290,8 +290,6 @@ object Codegen {
     case Reference(ref, nameWithType) =>
       for {
         descriptor <- descriptorFor(nameWithType.typ)
-        asmType <- asmTypeOf(nameWithType.typ.typ)
-        loadIns = loadInstructionFor(asmType)
         internalName = getInternalName(nameWithType.name, className)
         _ <- nameWithType.name match {
           case MemberName(_, _, _) =>

--- a/resolver/src/inc/resolver/Resolver.scala
+++ b/resolver/src/inc/resolver/Resolver.scala
@@ -48,12 +48,9 @@ object Resolver {
 
     case If(cond, thenExpr, elseExpr, pos) =>
       for {
-        r1 <- resolve(cond, tbl)
-        (c, _) = r1
-        r2 <- resolve(thenExpr, tbl)
-        (t, _) = r2
-        r3 <- resolve(elseExpr, tbl)
-        (e, _) = r3
+        (c, _) <- resolve(cond, tbl)
+        (t, _) <- resolve(thenExpr, tbl)
+        (e, _) <- resolve(elseExpr, tbl)
       } yield (If(c, t, e, NameWithPos(NoName, pos)), tbl)
 
     case Lambda(params, body, pos) =>
@@ -77,24 +74,20 @@ object Resolver {
       }
 
       for {
-        r1 <- resolvedParams
-        (parms, updatedTbl) = r1
-        r2 <- resolve(body, updatedTbl)
-        (b, _) = r2
+        (parms, updatedTbl) <- resolvedParams
+        (b, _) <- resolve(body, updatedTbl)
       } yield (Lambda(parms.toList, b, NameWithPos(NoName, pos)), tbl)
 
 
     case Apply(fn, args, pos) =>
       for {
-        rf <- resolve(fn, tbl)
-        (f, _) = rf
+        (f, _) <- resolve(fn, tbl)
 
         ra <- args.foldLeft(EmptyResult) {
           case (resSoFar, nextArg) =>
             for {
               rs <- resSoFar
-              a <- resolve(nextArg, tbl)
-              (r, _) = a
+              (r, _) <- resolve(nextArg, tbl)
             } yield rs :+ r
         }
 
@@ -127,10 +120,8 @@ object Resolver {
       val resolvedDecls = decls.foldLeft(emptyRes) {
         case (resSoFar, nextDecl) =>
           for {
-            r <- resSoFar
-            (resolvedSoFar, tblSoFar) = r
-            c <- resolve(module, nextDecl, tblSoFar)
-            (resolvedDecl, updatedTbl) = c
+            (resolvedSoFar, tblSoFar) <- resSoFar
+            (resolvedDecl, updatedTbl) <- resolve(module, nextDecl, tblSoFar)
           } yield (resolvedSoFar :+ resolvedDecl, updatedTbl)
       }
 

--- a/typechecker/src/inc/typechecker/Typechecker.scala
+++ b/typechecker/src/inc/typechecker/Typechecker.scala
@@ -133,24 +133,21 @@ object Typechecker {
     case If(cond, thenExpr, elseExpr, meta) =>
       for {
         // Typecheck the condition
-        r1 <- typecheck(cond, env, source)
-        (c, s1) = r1
+        (c, s1) <- typecheck(cond, env, source)
 
         NamePosType(_, _, condType) = c.meta
 
         _ = trace("If condition", c.meta.pos, condType, source)
 
         // Typecheck the then expression
-        r2 <- typecheck(thenExpr, env, source)
-        (t, s2) = r2
+        (t, s2) <- typecheck(thenExpr, env, source)
 
         NamePosType(_, _, thenType) = t.meta
 
         _ = trace("Then expression", t.meta.pos, thenType, source)
 
         // Typecheck the else expression
-        r3 <- typecheck(elseExpr, env, source)
-        (e, s3) = r3
+        (e, s3) <- typecheck(elseExpr, env, source)
 
         NamePosType(_, _, elseType) = e.meta
 
@@ -193,8 +190,7 @@ object Typechecker {
 
       for {
         // Typecheck the body with the params in scope
-        r <- typecheck(body, env ++ paramMappings, source)
-        (b, s1) = r
+        (b, s1) <- typecheck(body, env ++ paramMappings, source)
 
         _ = trace("Lambda body", b.meta.pos, b.meta.typ, source)
 
@@ -221,27 +217,22 @@ object Typechecker {
 
       for {
         // Typecheck the function
-        rf <- typecheck(fn, env, source)
-        (f, s1) = rf
+        (f, s1) <- typecheck(fn, env, source)
 
         _ = trace("Function to apply", f.meta.pos, f.meta.typ, source)
 
         // Typecheck the arg expressions
-        ra <- args.zipWithIndex.foldLeft(EmptyResult) {
+        (as, s2) <- args.zipWithIndex.foldLeft(EmptyResult) {
           case (resSoFar, (nextArg, idx)) =>
             for {
-              r <- resSoFar
-              (typedSoFar, substSoFar) = r
+              (typedSoFar, substSoFar) <- resSoFar
 
-              a <- typecheck(nextArg, substitute(env, s1), source)
-              (typedArg, newSubst) = a
+              (typedArg, newSubst) <- typecheck(nextArg, substitute(env, s1), source)
 
               _ = trace(s"Argument ${idx + 1}", typedArg.meta.pos, typedArg.meta.typ, source)
 
             } yield (typedSoFar :+ typedArg, chainSubstitution(substSoFar, newSubst))
         }
-
-        (as, s2) = ra
 
         s3 = chainSubstitution(s1, s2)
 
@@ -298,10 +289,8 @@ object Typechecker {
       val typecheckedDecls = decls.foldLeft(emptyRes) {
         case (resSoFar, nextDecl) =>
           for {
-            r <- resSoFar
-            (checkedSoFar, envSoFar) = r
-            c <- typecheck(nextDecl, envSoFar, source)
-            (checkedDecl, updatedEnv) = c
+            (checkedSoFar, envSoFar) <- resSoFar
+            (checkedDecl, updatedEnv) <- typecheck(nextDecl, envSoFar, source)
           } yield (checkedSoFar :+ checkedDecl, updatedEnv)
       }
 


### PR DESCRIPTION
There are a lot of bindings to tuples in the code that are needed only because of Scala's poor desugaring of for comprehensions