### PR TITLE
Make imports qualified by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ module Test.Func {
 ```scala
 module Test.Id {
   import Test.Func
-  let app = id(1)
+  let app = Func.id(1)
 }
 
 module Test.Compose {
   import Test.Func.{ compose, id }
-  let pointless = compose(id)(id)(1)
+  let pointless = Func.compose(Func.id)(Func.id)(1)
 }
 ```
 

--- a/build.sc
+++ b/build.sc
@@ -68,6 +68,7 @@ object common extends ScalaSettingsModule {
   def ivyDeps = T {
     super.ivyDeps() ++ Agg(
       ivy"org.typelevel::cats-core:1.6.0",
+      ivy"com.rklaehn::radixtree:0.5.1",
       ivy"org.typelevel::paiges-core:0.2.1",
       ivy"com.lihaoyi::fansi:0.2.5",
       ivy"com.outr::scribe:2.7.1"

--- a/codegen/test/src/inc/codegen/CodegenSpec.scala
+++ b/codegen/test/src/inc/codegen/CodegenSpec.scala
@@ -22,7 +22,7 @@ class CodegenSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChe
     Let(name, binding, NamePosType(LocalName(name), Pos.Empty, binding.meta.typ))
 
   def mkInt(i: Int) = LiteralInt(i, NamePosType(NoName, Pos.Empty, TypeScheme(Type.Int)))
-  def mkRef(r: String, typ: TypeScheme) = Reference(r, NamePosType(NoName, Pos.Empty, typ))
+  def mkRef(r: String, typ: TypeScheme) = Reference(List(r), NamePosType(NoName, Pos.Empty, typ))
   def mkUnit() = LiteralUnit(NamePosType(NoName, Pos.Empty, TypeScheme(Type.Unit)))
 
   "Codegen" should "generate code for a simple module" in {

--- a/common/src/inc/common/Printer.scala
+++ b/common/src/inc/common/Printer.scala
@@ -102,7 +102,7 @@ object Printer {
     case LiteralUnit(_) =>
       Doc.text("()")
     case Reference(ref, _) =>
-      Doc.text(ref)
+      Doc.intercalate(Doc.char('.'), ref.map(Doc.text))
     case If(c, t, e, _) =>
       Doc.text("if") & print(c) /
         (Doc.text("then") & print(t)).nested(2) /

--- a/common/src/inc/common/TypeScheme.scala
+++ b/common/src/inc/common/TypeScheme.scala
@@ -1,6 +1,9 @@
 package inc.common
 
+import cats.instances.string._
+import com.rklaehn.radixtree._
 import java.lang.String
+import scala.Array
 import scala.collection.immutable.{ List, Map, Set }
 
 case class TypeScheme(bound: List[TypeVariable], typ: Type) {
@@ -26,7 +29,7 @@ case class TypeScheme(bound: List[TypeVariable], typ: Type) {
 object TypeScheme {
   def apply(typ: Type): TypeScheme = TypeScheme(List.empty, typ)
 
-  def generalize(env: Map[String, TypeScheme], typ: Type): TypeScheme = {
+  def generalize(env: RadixTree[Array[String], TypeScheme], typ: Type): TypeScheme = {
     val freeInEnv = env.values.flatMap(_.freeTypeVariables).toSet
     val bound = typ.freeTypeVariables diff freeInEnv
     val scheme = TypeScheme(bound.toList, typ)

--- a/main/test/src/inc/main/MainSpec.scala
+++ b/main/test/src/inc/main/MainSpec.scala
@@ -178,8 +178,8 @@ class MainSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks
       """
       |module Test.Apply {
       |  import Test.Id
-
-      |  let int = id(1)
+      |
+      |  let int = Id.id(1)
       |}
       """.trim.stripMargin
 

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -26,6 +26,7 @@ object Parser {
 
   // Separators
   def maybeSemi[_: P] = P(";".? ~ allWs)
+  def dot[_: P] = P("." ~ allWs)
   def comma[_: P] = P("," ~ allWs)
 
   // Literals
@@ -109,9 +110,9 @@ object Parser {
   def inBraces[_: P, A](p: => P[A]) = P("{" ~/ allWs ~ p ~ allWs ~ "}")
   def inParens[_: P, A](p: => P[A]) = P("(" ~/ allWs ~ p ~ allWs ~ ")")
 
-  def reference[_: P] = P(Index ~ identifier ~ Index).map {
+  def reference[_: P] = P(Index ~ identifier.rep(sep = dot) ~ Index).map {
     case (from, id, to) =>
-      Reference(id, Pos(from, to))
+      Reference(id.toList, Pos(from, to))
   }
 
   def ifExpr[_: P] = P(

--- a/parser/test/src/inc/parser/ParserSpec.scala
+++ b/parser/test/src/inc/parser/ParserSpec.scala
@@ -176,12 +176,12 @@ class ParserSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChec
   it should "parse references to other fields" in {
     val mod = Module(List.empty, "Float", List.empty, List(
       Let("float", LiteralFloat(3.142f, ()), ()),
-      Let("float2", Reference("float", ()), ())
+      Let("float2", Reference(List("float"), ()), ())
     ), ())
     val mod2 = Module(List.empty, "Double", List.empty, List(
       Let("double", LiteralDouble(3.142d, ()), ()),
       Let("double2", LiteralDouble(0.0001d, ()), ()),
-      Let("double3", Reference("double2", ()), ())
+      Let("double3", Reference(List("double2"), ()), ())
     ), ())
 
     parseModule(

--- a/resolver/test/src/inc/resolver/ResolverSpec.scala
+++ b/resolver/test/src/inc/resolver/ResolverSpec.scala
@@ -15,7 +15,7 @@ class ResolverSpec extends FlatSpec with Matchers {
     Let(name, binding, Pos.Empty)
 
   def mkInt(i: Int) = LiteralInt(i, Pos.Empty)
-  def mkRef(r: String) = Reference(r, Pos.Empty)
+  def mkRef(r: String) = Reference(List(r), Pos.Empty)
 
   def mkResolvedModule(name: String, decls: List[TopLevelDeclaration[NameWithPos]]) = Module(
     pkg = List("Test", "Resolver"),

--- a/typechecker/test/src/inc/typechecker/TypecheckerSpec.scala
+++ b/typechecker/test/src/inc/typechecker/TypecheckerSpec.scala
@@ -1,5 +1,7 @@
 package inc.typechecker
 
+import cats.instances.string._
+import com.rklaehn.radixtree._
 import inc.common._
 import org.scalatest._
 
@@ -17,7 +19,7 @@ class TypecheckerSpec extends FlatSpec with Matchers {
   def mkInt(i: Int) = LiteralInt(i, NameWithPos(NoName, Pos.Empty))
   def mkDbl(d: Double) = LiteralDouble(d, NameWithPos(NoName, Pos.Empty))
   def mkBool(b: Boolean) = LiteralBoolean(b, NameWithPos(NoName, Pos.Empty))
-  def mkRef(r: String) = Reference(r, NameWithPos(NoName, Pos.Empty))
+  def mkRef(r: String) = Reference(List(r), NameWithPos(NoName, Pos.Empty))
 
   def mkIf(cond: Expr[NameWithPos], thenExpr: Expr[NameWithPos], elseExpr: Expr[NameWithPos]) =
     If(cond, thenExpr, elseExpr, NameWithPos(NoName, Pos.Empty))
@@ -42,9 +44,9 @@ class TypecheckerSpec extends FlatSpec with Matchers {
     Let(name, binding, NamePosType(LocalName(name), Pos.Empty, binding.meta.typ))
 
   def mkCheckedInt(i: Int) = LiteralInt(i, NamePosType(NoName, Pos.Empty, TypeScheme(Type.Int)))
-  def mkCheckedRef(r: String, typ: TypeScheme) = Reference(r, NamePosType(NoName, Pos.Empty, typ))
+  def mkCheckedRef(r: String, typ: TypeScheme) = Reference(List(r), NamePosType(NoName, Pos.Empty, typ))
 
-  val noImports = Map.empty[String, TopLevelDeclaration[NameWithType]]
+  val noImports = RadixTree.empty[Array[String], TopLevelDeclaration[NameWithType]]
 
   "Typechecker" should "typecheck let bound literals successfully" in {
     val mod = mkModule("Int", List(mkLet("int", mkInt(42))))


### PR DESCRIPTION
Makes imports qualified by default

* parsing of dot-separated qualified identifiers
* a slightly better representation of environments (radix tree)