### PR TITLE
Use fastparse's built in whitespace handling

### DIFF
--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -53,7 +53,7 @@ object Parser {
   ).map {
     case (from, s, to) =>
       LiteralString(s, Pos(from, to))
-  }.log
+  }
 
   def literalIntegral[_: P] = P(Index ~ (zero | digitsLeadingOneToNine) ~~ CharIn("lL").?.! ~ Index).map {
     case (from, num, suffix, to) =>
@@ -137,7 +137,7 @@ object Parser {
   ).map {
     case (from, params, expr, to) =>
       Lambda(params.toList, expr, Pos(from, to))
-  }.log
+  }
 
   def application[_: P]: P[Expr[Pos] => Expr[Pos]] = P(
     inParens(expression.rep(sep = comma./)) ~ Index

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -28,7 +28,7 @@ object Parser {
   def oneToNine[_: P] = P(CharIn("1-9").!)
   def zeroToNine[_: P] = P(CharIn("0-9").!)
   def digits[_: P] = P(CharsWhileIn("0-9", 0).!)
-  def digitsLeadingOneToNine[_: P] = P((oneToNine ~ digits) map { case (first, rest) => first + rest })
+  def digitsLeadingOneToNine[_: P] = P((oneToNine ~~ digits) map { case (first, rest) => first + rest })
 
   def literalBoolean[_: P] = P(Index ~ StringIn("true", "false").! ~ Index).map {
     case (from, b, to) =>
@@ -39,7 +39,7 @@ object Parser {
   val charDisallowedChars = "\'" + disallowedChars
   val stringDisallowedChars = "\"" + disallowedChars
 
-  def literalChar[_: P] = P(Index ~ "'" ~/ CharPred(c => !charDisallowedChars.contains(c)).! ~ "'" ~ Index).map {
+  def literalChar[_: P] = P(Index ~ "'" ~~/ CharPred(c => !charDisallowedChars.contains(c)).! ~~ "'" ~ Index).map {
     case (from, s, to) => LiteralChar(s(0), Pos(from, to))
   }
 
@@ -52,7 +52,7 @@ object Parser {
       LiteralString(s, Pos(from, to))
   }
 
-  def literalIntegral[_: P] = P(Index ~ (zero | digitsLeadingOneToNine) ~ CharIn("lL").?.! ~ Index).map {
+  def literalIntegral[_: P] = P(Index ~ (zero | digitsLeadingOneToNine) ~~ CharIn("lL").?.! ~ Index).map {
     case (from, num, suffix, to) =>
       if (suffix.isEmpty)
         LiteralInt(Integer.parseInt(num), Pos(from, to))
@@ -61,7 +61,7 @@ object Parser {
   }
 
   def exponentPart[_: P] = P(
-    (CharIn("eE").! ~/ CharIn("+\\-").?.! ~ digits).?
+    (CharIn("eE").! ~~/ CharIn("+\\-").?.! ~~ digits).?
   ).map {
     case Some((exponentIndicator, sign, digits)) =>
       exponentIndicator + sign + digits.mkString
@@ -71,7 +71,7 @@ object Parser {
 
   def literalFloatingPoint[_: P] = P(
     Index ~
-      (zero | digitsLeadingOneToNine) ~ "." ~/ digits ~ exponentPart ~ CharIn("dDfF").?.! ~
+      (zero | digitsLeadingOneToNine) ~~ "." ~~/ digits ~~ exponentPart ~~ CharIn("dDfF").?.! ~
       Index
   ).map {
     case (from, wholeNumberPart, fractionPart, exponentPart, "", to) =>
@@ -96,7 +96,7 @@ object Parser {
       literalUnit
 
   // Identifiers
-  def identifier[_: P] = !ReservedWords ~ P((CharPred(Character.isJavaIdentifierStart).! ~ CharsWhile(Character.isJavaIdentifierPart, 0).!).map {
+  def identifier[_: P] = !ReservedWords ~ P((CharPred(Character.isJavaIdentifierStart).! ~~ CharsWhile(Character.isJavaIdentifierPart, 0).!).map {
     case (first, rest) => first + rest
   })
 

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -48,12 +48,12 @@ object Parser {
 
   def literalString[_: P] = P(
     Index ~
-      "\"" ~/ CharsWhile(c => !stringDisallowedChars.contains(c), 0).! ~ "\"" ~
+      "\"" ~~/ CharsWhile(c => !stringDisallowedChars.contains(c), 0).! ~~ "\"" ~
       Index
   ).map {
     case (from, s, to) =>
       LiteralString(s, Pos(from, to))
-  }
+  }.log
 
   def literalIntegral[_: P] = P(Index ~ (zero | digitsLeadingOneToNine) ~~ CharIn("lL").?.! ~ Index).map {
     case (from, num, suffix, to) =>
@@ -137,7 +137,7 @@ object Parser {
   ).map {
     case (from, params, expr, to) =>
       Lambda(params.toList, expr, Pos(from, to))
-  }
+  }.log
 
   def application[_: P]: P[Expr[Pos] => Expr[Pos]] = P(
     inParens(expression.rep(sep = comma./)) ~ Index
@@ -202,7 +202,7 @@ object Parser {
       case Parsed.Success(mod, _) =>
         Right(mod)
       case f @ Parsed.Failure(_, _, _) =>
-        val errorMessage = f.trace().msg
+        val errorMessage = "\n\n" + f.trace().longAggregateMsg + "\n\n" + f.trace().longTerminalsMsg
         ParserError.singleton(errorMessage)
     }
   }

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -18,7 +18,7 @@ object Parser {
       "else"
     ) ~~ nonZeroWs
   )
-  
+
   // Whitespace
   def nonZeroWs[_: P] = P(CharsWhile(Character.isWhitespace, 1))
 

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -16,8 +16,11 @@ object Parser {
       "if",
       "then",
       "else"
-    )
+    ) ~~ nonZeroWs
   )
+  
+  // Whitespace
+  def nonZeroWs[_: P] = P(CharsWhile(Character.isWhitespace, 1))
 
   // Separators
   def maybeSemi[_: P] = P(";".?)
@@ -96,7 +99,7 @@ object Parser {
       literalUnit
 
   // Identifiers
-  def identifier[_: P] = !ReservedWords ~ P((CharPred(Character.isJavaIdentifierStart).! ~~ CharsWhile(Character.isJavaIdentifierPart, 0).!).map {
+  def identifier[_: P] = !ReservedWords ~~ P((CharPred(Character.isJavaIdentifierStart).! ~~ CharsWhile(Character.isJavaIdentifierPart, 0).!).map {
     case (first, rest) => first + rest
   })
 


### PR DESCRIPTION
Fastparse has built-in support for various whitespace handlers (this one even supports nested comments).

That tidies up the parser quite a bit.