### PR TITLE
Disambiguate package access syntax from member access syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a hobby project. Expect lots of bugs and don't expect to be able to use 
 
 ## Getting started
 
-This project is built with [mill](https://www.lihaoyi.com/mill/) version 0.3.6 and requires Java 8 or above to be installed.
+This project is built with [mill](https://www.lihaoyi.com/mill/) version 0.5.2 and requires Java 8 or above to be installed.
 
 To build the project:
 
@@ -100,12 +100,12 @@ module Test/Func {
 
 ```scala
 module Test/Id {
-  import Test.Func
+  import Test/Func
   let app = id(1)
 }
 
 module Test/Compose {
-  import Test.Func.{ compose, id }
+  import Test/Func.{ compose, id }
   let pointless = compose(id)(id)(1)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module Test {}
 ### Let bindings and literals
 
 ```scala
-module Test.Let {
+module Test/Let {
   let litInt = 42
   let litLong = 42L
   let litFloat = 42.0F
@@ -82,7 +82,7 @@ module Test.Let {
 ### If expressions
 
 ```scala
-module Test.If {
+module Test/If {
   let choose = if true then 1 else 0
 }
 ```
@@ -90,7 +90,7 @@ module Test.If {
 ### Functions
 
 ```scala
-module Test.Func {
+module Test/Func {
   let id = a -> a
   let compose = f -> g -> a -> f(g(a))
 }
@@ -99,12 +99,12 @@ module Test.Func {
 ### Imports
 
 ```scala
-module Test.Id {
+module Test/Id {
   import Test.Func
   let app = id(1)
 }
 
-module Test.Compose {
+module Test/Compose {
   import Test.Func.{ compose, id }
   let pointless = compose(id)(id)(1)
 }

--- a/bench/Church.inc
+++ b/bench/Church.inc
@@ -1,4 +1,4 @@
-module Test.Church {
+module Test/Church {
     let zero = a -> a
     let one = f -> a -> f(a)
     let two = f -> a -> f(f(a))

--- a/bench/Const.inc
+++ b/bench/Const.inc
@@ -1,4 +1,4 @@
-module Test.Const {
+module Test/Const {
     let const = (a, b) -> a
     let str = a -> "a"
     let app = const(str(const(32, 43)), "a")

--- a/bench/Lambda.inc
+++ b/bench/Lambda.inc
@@ -1,4 +1,4 @@
-module Test.Main.Lambda {
+module Test/Main/Lambda {
     let x = 42
     let y = 41
     let lam = bool -> if bool then x else y

--- a/bench/Occurs.inc
+++ b/bench/Occurs.inc
@@ -1,3 +1,3 @@
-module Test.Occurs {
+module Test/Occurs {
     let occ = f -> f(f)
 }

--- a/common/src/inc/common/Printer.scala
+++ b/common/src/inc/common/Printer.scala
@@ -144,14 +144,14 @@ object Printer {
 
   def print[A](mod: Module[A]): Doc = {
     val Module(pkg, name, imports, declarations @ _, _) = mod
-    val prefix = Doc.text("module") & Doc.text((pkg :+ name).mkString(".")) & Doc.char('{')
+    val prefix = Doc.text("module") & Doc.text((pkg :+ name).mkString("/")) & Doc.char('{')
     val suffix = Doc.char('}')
 
     val imps = Doc.intercalate(Doc.char(';') + Doc.line, imports.map {
       case ImportModule(pkg, name, _) =>
-        Doc.text("import") & Doc.text((pkg :+ name).mkString("."))
+        Doc.text("import") & Doc.text((pkg :+ name).mkString("/"))
       case ImportSymbols(pkg, name, syms, _) =>
-        val impPrefix = Doc.text("import") & Doc.text((pkg :+ name).mkString(".")) + Doc.char('.') + Doc.char('{')
+        val impPrefix = Doc.text("import") & Doc.text((pkg :+ name).mkString("/")) + Doc.char('.') + Doc.char('{')
         val impSuffix = Doc.char('}')
         val impBody = Doc.intercalate(Doc.comma + Doc.line, syms.map(Doc.text))
         impBody.bracketBy(impPrefix, impSuffix)

--- a/common/test/src/inc/common/Generators.scala
+++ b/common/test/src/inc/common/Generators.scala
@@ -31,9 +31,16 @@ trait Generators { self: Matchers =>
   val boolGen: Gen[Expr[NamePosType]] =
     Arbitrary.arbitrary[Boolean].map(LiteralBoolean(_, NamePosType(NoName, Pos.Empty, TypeScheme(Type.Boolean))))
   val charGen: Gen[Expr[NamePosType]] =
-    Arbitrary.arbitrary[Char].map(LiteralChar(_, NamePosType(NoName, Pos.Empty, TypeScheme(Type.Char))))
+    Gen.asciiPrintableChar.filterNot { chr =>
+      // Parsing char and string escapes is not implemented yet
+      chr == '\n' ||
+        chr == '\r' ||
+        chr == '\\' ||
+        chr == '\''
+    }.map(LiteralChar(_, NamePosType(NoName, Pos.Empty, TypeScheme(Type.Char))))
   val strGen: Gen[Expr[NamePosType]] =
     Gen.asciiPrintableStr.filterNot { str =>
+      // Parsing char and string escapes is not implemented yet
       str.contains('\n') ||
       str.contains('\r') ||
       str.contains('\\') ||

--- a/common/test/src/inc/common/Generators.scala
+++ b/common/test/src/inc/common/Generators.scala
@@ -68,8 +68,10 @@ trait Generators { self: Matchers =>
           Param(nm, NamePosType(LocalName(nm), Pos.Empty, tp))
       }
       body <- exprGen(
-        // Unpleasant trick to allow later generators to refer to v
-        decls ++ ps.map { p =>
+        // Trick to allow later generators to refer to params;
+        // we need to filter out any existing declarations that
+        // clash with our params, since params can shadow top level declarations
+        decls.filterNot(d => !ps.exists(_.name == d.name)) ++ ps.map { p =>
           Let(p.name, Reference(p.name, p.meta), p.meta)
         }
       )

--- a/common/test/src/inc/common/Generators.scala
+++ b/common/test/src/inc/common/Generators.scala
@@ -78,7 +78,7 @@ trait Generators { self: Matchers =>
         // Trick to allow later generators to refer to params;
         // we need to filter out any existing declarations that
         // clash with our params, since params can shadow top level declarations
-        decls.filterNot(d => !ps.exists(_.name == d.name)) ++ ps.map { p =>
+        decls.filterNot(d => ps.exists(_.name == d.name)) ++ ps.map { p =>
           Let(p.name, Reference(p.name, p.meta), p.meta)
         }
       )

--- a/main/src/inc/main/Main.scala
+++ b/main/src/inc/main/Main.scala
@@ -178,7 +178,7 @@ object Main {
 
       val afterAll = System.nanoTime
 
-      val name = if (mod.pkg.isEmpty) mod.name else mod.pkg.mkString(".") + "." + mod.name
+      val name = if (mod.pkg.isEmpty) mod.name else mod.pkg.mkString("/") + "/" + mod.name
 
       scribe.info(NL + Blue(s"""Compiled ${name} in """) + White(s"""${(afterAll - beforeAll) / 1000000}ms"""))
 

--- a/parser/src/inc/parser/Parser.scala
+++ b/parser/src/inc/parser/Parser.scala
@@ -195,10 +195,12 @@ object Parser {
 
   def decl[_: P] = P(letDeclaration)
 
+  def importedSymbols[_: P] = P( inBraces(identifier.rep(min = 1, sep = comma./)) | identifier.map(Seq(_)) )
+
   def imports[_: P] = P {
     Index ~
-      "import" ~/ identifier.rep(min = 1, sep = ".") ~
-      ("." ~ inBraces(identifier.rep(min = 1, sep = comma./))).? ~
+      "import" ~/ identifier.rep(min = 1, sep = "/") ~
+      ("." ~ importedSymbols).? ~
       Index
   }.map {
     case (from, ident, Some(symbols), to) =>
@@ -217,7 +219,7 @@ object Parser {
 
   def module[_: P] = P {
     Index ~
-    "module" ~/ identifier.rep(min = 1, sep = ".") ~
+    "module" ~/ identifier.rep(min = 1, sep = "/") ~
       bracesBlock ~ Index ~
       End
   }.map {

--- a/parser/test/src/inc/parser/ParserSpec.scala
+++ b/parser/test/src/inc/parser/ParserSpec.scala
@@ -217,12 +217,12 @@ class ParserSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChe
 
     parseModule(
       """
-      |module Test.Float { let float = 3.142f }
+      |module Test/Float { let float = 3.142f }
       |""".trim.stripMargin) shouldBe mod
 
     parseModule(
       """
-      |module Test.Parser.Double { let double = 3.142; let double2 = 0.0001 }
+      |module Test/Parser/Double { let double = 3.142; let double2 = 0.0001 }
       |""".trim.stripMargin) shouldBe mod2
   }
 
@@ -242,12 +242,12 @@ class ParserSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChe
 
     parseModule(
       """
-      |module Test.Float { import Test.Import; let float = 3.142f }
+      |module Test/Float { import Test/Import; let float = 3.142f }
       |""".trim.stripMargin) shouldBe mod
 
     parseModule(
       """
-      |module Test.Parser.Double { import Test.Import.{ foo, bar, Baz }; let double = 3.142; let double2 = 0.0001 }
+      |module Test/Parser/Double { import Test/Import.{ foo, bar, Baz }; let double = 3.142; let double2 = 0.0001 }
       |""".trim.stripMargin) shouldBe mod2
   }
 


### PR DESCRIPTION
Changes package access syntax to use `/` instead of `.`, e.g.

```
module Test/Func {
  let id = a -> a
  let compose = f -> g -> a -> f(g(a))
}

module Test/Id {
  import Test/Func
  let app = id(1)
}

module Test/Compose {
  import Test/Func.{ compose, id }
  let pointless = compose(id)(id)(1)
}
```

This initially looks a little scary, but it's a change that I've been thinking about making for a while. The motivation is to disambiguate package access from member access, which means we don't have to do anything to decide whether something is a module or a member of a module in an import statement.

The JVM already stores package structure this way (see e.g. `javap` output).

This is the reason that `/` was chosen as the package indexing operator, along with the fact that it's available without pressing any modifier keys.

The alternative would be to change the member access syntax (see e.g. Ocaml's `#` operator).

This should also provide an easy first case for member constraints in the type checker as they can initially be implemented for accessing members of modules before support for declaring and using data types is implemented.