### PR TITLE
Add type applications & kinds to the AST to support kind inference

### DIFF
--- a/common/src/inc/common/Kind.scala
+++ b/common/src/inc/common/Kind.scala
@@ -1,0 +1,54 @@
+package inc.common
+
+import java.lang.Exception
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.immutable.{ List, Map }
+import scala.Int
+
+sealed trait Kind {
+  def substitute(subst: Map[KindVariable, Kind]): Kind = this match {
+    case Atomic =>
+      Atomic
+    case kindVar @ KindVariable(_) =>
+      subst.getOrElse(kindVar, kindVar)
+    case Parameterized(params, result) =>
+      Parameterized(params.map(_.substitute(subst)), result.substitute(subst))
+  }
+
+  def toProto: proto.Kind = this match {
+    case Atomic =>
+      proto.Atomic()
+    case KindVariable(id) =>
+      proto.KindVariable(id)
+    case Parameterized(params, result) =>
+      proto.Parameterized(params.map(_.toProto), result.toProto)
+  }
+}
+
+object Kind {
+  def Function(arity: Int): Kind =
+    Parameterized(List.fill(arity)(Atomic), Atomic)
+
+  def fromProto(kind: proto.Kind): Kind = kind match {
+    case proto.Atomic() =>
+      Atomic
+    case proto.Parameterized(params, result) =>
+      Parameterized(params.map(Kind.fromProto).toList, Kind.fromProto(result))
+    case proto.KindVariable(_) =>
+      throw new Exception("Unexpected kind variable in protobuf")
+    case proto.Kind.Empty =>
+      throw new Exception("Empty Kind in protobuf")
+  }
+}
+
+case object Atomic extends Kind
+
+case class Parameterized(params: List[Kind], result: Kind) extends Kind
+
+case class KindVariable(id: Int) extends Kind
+
+object KindVariable {
+  val nextId = new AtomicInteger(1)
+  def apply(): KindVariable = KindVariable(nextId.getAndIncrement)
+}
+

--- a/common/src/inc/common/KindConstraint.scala
+++ b/common/src/inc/common/KindConstraint.scala
@@ -1,0 +1,13 @@
+package inc.common
+
+import scala.{ Product, Serializable }
+import scala.collection.immutable.Map
+
+sealed trait KindConstraint extends Product with Serializable {
+  def pos: Pos
+  def substitute(subst: Map[KindVariable, Kind]): KindConstraint = this match {
+    case EqualKind(l, r, pos) => EqualKind(l.substitute(subst), r.substitute(subst), pos)
+  }
+}
+
+case class EqualKind(l: Kind, r: Kind, pos: Pos) extends KindConstraint

--- a/common/src/inc/common/Module.scala
+++ b/common/src/inc/common/Module.scala
@@ -24,8 +24,10 @@ final case class Module[A](
 
   def fullName = (pkg :+ name).mkString("/")
 
-  def substitute(subst: Map[TypeVariable, Type])(implicit eqv: A =:= NamePosType): Module[A] =
-    this.map(a => eqv(a).substitute(subst).asInstanceOf[A])
+  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): Module[A] = {
+    val from = to.flip
+    this.map(a => from(to(a).substitute(subst)))
+  }
 }
 
 object Module {

--- a/common/src/inc/common/TopLevelDeclaration.scala
+++ b/common/src/inc/common/TopLevelDeclaration.scala
@@ -18,8 +18,10 @@ sealed trait TopLevelDeclaration[A] extends Product with Serializable {
       proto.Let(name, expr.toProto, nameWithType)
   }
 
-  def substitute(subst: Map[TypeVariable, Type])(implicit eqv: A =:= NamePosType): TopLevelDeclaration[A] =
-    this.map(a => eqv(a).substitute(subst).asInstanceOf[A])
+  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): TopLevelDeclaration[A] = {
+    val from = to.flip
+    this.map(a => from(to(a).substitute(subst)))
+  }
 }
 
 object TopLevelDeclaration {

--- a/common/src/inc/common/Type.scala
+++ b/common/src/inc/common/Type.scala
@@ -2,33 +2,46 @@ package inc.common
 
 import java.lang.{ Exception, String }
 import java.util.concurrent.atomic.AtomicInteger
-import scala.Int
+import scala.{ Int, StringContext }
 import scala.collection.immutable.{ List, Map, Set }
 
 sealed trait Type {
+  def kind: Kind
+
   def toProto: proto.Type = this match {
-    case TypeVariable(i) => proto.TypeVariable(i)
-    case TypeConstructor(name, tyParams) => proto.TypeConstructor(name, tyParams.map(_.toProto))
+    case TypeVariable(i, kind) =>
+      proto.TypeVariable(i, kind.toProto)
+    case TypeApply(typ, params) =>
+      proto.TypeApply(typ.toProto, params.map(_.toProto))
+    case TypeConstructor(name, kind) =>
+      proto.TypeConstructor(name, kind.toProto)
   }
 
   def isPrimitive = this match {
-    case TypeConstructor(name, _) if Type.primitives.contains(name) =>
-      true
+    case TypeConstructor(name, _) =>
+      Type.primitives.contains(name)
     case _ =>
       false
   }
 
   def freeTypeVariables: Set[TypeVariable] = this match {
-    case tyVar @ TypeVariable(_) => Set(tyVar)
-    case TypeConstructor(_, tyParams) =>
-      tyParams.flatMap(_.freeTypeVariables).toSet
+    case tyVar @ TypeVariable(_, _) =>
+      Set(tyVar)
+    case TypeApply(tyVar @ TypeVariable(_, _), params) =>
+      params.flatMap(_.freeTypeVariables).toSet + tyVar
+    case TypeApply(typ, params) =>
+      typ.freeTypeVariables ++ params.flatMap(_.freeTypeVariables).toSet
+    case TypeConstructor(_, _) =>
+      Set.empty
   }
 
   def substitute(subst: Map[TypeVariable, Type]): Type = this match {
-    case tyVar @ TypeVariable(_) =>
+    case tyVar @ TypeVariable(_, _) =>
       subst.getOrElse(tyVar, tyVar)
-    case TypeConstructor(nm, tyParams) =>
-      TypeConstructor(nm, tyParams.map(_.substitute(subst)))
+    case tyCon @ TypeConstructor(_, _) =>
+      tyCon
+    case TypeApply(typ, params) =>
+      TypeApply(typ.substitute(subst), params.map(_.substitute(subst)))
   }
 }
 
@@ -37,35 +50,52 @@ object Type {
 
   val primitives = Set("Int", "Long", "Float", "Double", "Boolean", "Char")
 
-  val Int = TypeConstructor("Int", List.empty)
-  val Long = TypeConstructor("Long", List.empty)
-  val Float = TypeConstructor("Float", List.empty)
-  val Double = TypeConstructor("Double", List.empty)
-  val Boolean = TypeConstructor("Boolean", List.empty)
-  val Char = TypeConstructor("Char", List.empty)
-  val String = TypeConstructor("String", List.empty)
-  val Module = TypeConstructor("Module", List.empty)
-  val Unit = TypeConstructor(UnitClass, List.empty)
-  def Function(from: List[Type], to: Type) = TypeConstructor("->", from ++ List(to))
+  val Int = TypeConstructor("Int", Atomic)
+  val Long = TypeConstructor("Long", Atomic)
+  val Float = TypeConstructor("Float", Atomic)
+  val Double = TypeConstructor("Double", Atomic)
+  val Boolean = TypeConstructor("Boolean", Atomic)
+  val Char = TypeConstructor("Char", Atomic)
+  val String = TypeConstructor("String", Atomic)
+  val Module = TypeConstructor("Module", Atomic)
+  val Unit = TypeConstructor(UnitClass, Atomic)
+  def Function(from: List[Type], to: Type) = {
+    TypeApply(
+      TypeConstructor("->", Parameterized(from.map(_ => Atomic), Atomic)),
+      from :+ to)
+  }
 
   def fromProto(typ: proto.Type): Type = typ match {
-    case proto.TypeVariable(id) =>
-      TypeVariable(id)
-    case proto.TypeConstructor(name, typeParams) =>
-      TypeConstructor(name, typeParams.toList.map(Type.fromProto))
+    case proto.TypeVariable(id, kind) =>
+      TypeVariable(id, Kind.fromProto(kind))
+    case proto.TypeConstructor(name, kind) =>
+      TypeConstructor(name, Kind.fromProto(kind))
+    case proto.TypeApply(typ, params) =>
+      TypeApply(Type.fromProto(typ), params.map(Type.fromProto).toList)
     case proto.Type.Empty =>
       throw new Exception("Empty Type in protobuf")
   }
 }
 
-case class TypeVariable(id: Int) extends Type {
+case class TypeVariable(id: Int, kind: Kind) extends Type {
   def occursIn(typ: Type) = typ.freeTypeVariables.contains(this)
 }
 
 object TypeVariable {
-  def fromProto(tyVar: proto.TypeVariable) = TypeVariable(tyVar.id)
-  val nextVariableId = new AtomicInteger(1)
-  def apply(): TypeVariable = TypeVariable(nextVariableId.getAndIncrement)
+  val nextId = new AtomicInteger(1)
+  def apply(kind: Kind = Atomic): TypeVariable =
+    TypeVariable(nextId.getAndIncrement, kind)
+  def fromProto(tyVar: proto.TypeVariable) =
+    TypeVariable(tyVar.id, Atomic)
 }
 
-case class TypeConstructor(name: String, typeParams: List[Type]) extends Type
+case class TypeConstructor(name: String, kind: Kind) extends Type
+
+case class TypeApply(typ: Type, params: List[Type]) extends Type {
+  def kind: Kind = typ.kind match {
+    case Parameterized(_, result) =>
+      result
+    case _ =>
+      throw new Exception(s"Type application ${Printer.print(this).render(80)} has unexpected kind ${typ.kind}")
+  }
+}

--- a/common/test/src/inc/common/Generators.scala
+++ b/common/test/src/inc/common/Generators.scala
@@ -140,7 +140,7 @@ trait Generators { self: Matchers =>
 
       Let(nm, Lambda(_, _, _), lambdaMeta) = lam
 
-      TypeScheme(_, TypeConstructor("->", tpArgs)) = lambdaMeta.typ
+      TypeScheme(_, TypeApply(TypeConstructor("->", _), tpArgs)) = lambdaMeta.typ
 
       args <- tpArgs.init.traverse(tp => genArg(tp)(decls))
 

--- a/main/src/inc/main/Configuration.scala
+++ b/main/src/inc/main/Configuration.scala
@@ -16,6 +16,6 @@ case class Configuration(
 
 object Configuration {
   val default = Configuration()
-  val test = Configuration(verifyCodegen = true)
+  val test = Configuration(verifyCodegen = true, traceTyper = true)
   val printTimings = Configuration(printPhaseTiming = true)
 }

--- a/proto/protobuf/ast.proto
+++ b/proto/protobuf/ast.proto
@@ -12,19 +12,45 @@ message Import {
   Symbols symbols = 3;
 }
 
+message Atomic {}
+
+message Parameterized {
+  repeated Kind params = 1;
+  Kind result = 2;
+}
+
+message KindVariable {
+  int32 id = 1;
+}
+
+message Kind {
+  oneof sealed_value {
+    Atomic atomic = 1;
+    Parameterized parameterized = 2;
+    KindVariable kindVar = 3;
+  }
+}
+
 message TypeVariable {
   int32 id = 1;
+  Kind kind = 2;
 }
 
 message TypeConstructor {
   string name = 1;
-  repeated Type typeParams = 2;
+  Kind kind = 2;
+}
+
+message TypeApply {
+  Type typ = 1;
+  repeated Type params = 2;
 }
 
 message Type {
   oneof sealed_value {
     TypeVariable tyVar = 1;
     TypeConstructor tyCon = 2;
+    TypeApply tyApp = 3;
   }
 }
 

--- a/typechecker/src/inc/typechecker/Gather.scala
+++ b/typechecker/src/inc/typechecker/Gather.scala
@@ -271,9 +271,16 @@ class Gather(solve: Solve, context: Printer.SourceContext, isTraceEnabled: Boole
     module match {
       case Module(_, _, _, decls, meta) =>
 
-        val initialEnv = importedDecls.view.map {
-          case (sym, tld) => (sym, tld.meta.typ)
+        val importedEnv = importedDecls.view.map {
+          case (sym, tld) => sym -> tld.meta.typ
         }.toMap
+
+        val initialDecls = decls.flatMap {
+          case Let(name, _, _) =>
+            List(name -> TypeScheme(List.empty, TypeVariable()))
+        }.toMap
+
+        val initialEnv = importedEnv ++ initialDecls
 
         val emptyRes: Infer[(Chain[TopLevelDeclaration[NamePosType]], Environment, List[Constraint])] =
           Right((Chain.empty, initialEnv, List.empty))


### PR DESCRIPTION
Until now there has not been any way for the user to introduce type variables as there is no support for type ascriptions at the top level and ascriptions within expressions may not introduce a type scheme.

However #23 changes that by introducing data types and their constructors, which may be parameterized. 

Although this is a bit of a premature change, it seems easier to replace the existing representation (TypeConstructors with lists of Types) with type applications and kinds at this point rather than trying to retrofit TypeVariables to have parameter lists in #23. 

This will make it easier to introduce kind inference for type variables based on their usage in data constructors, as we need to be able to store the kinds of type variables and type constructors to ensure that they are applied in the right way in ascriptions.