### PR TITLE
Add named type variables

### DIFF
--- a/codegen/src/inc/codegen/Codegen.scala
+++ b/codegen/src/inc/codegen/Codegen.scala
@@ -207,7 +207,9 @@ class Codegen(verifyCodegen: Boolean) {
       }.leftFlatMap { _ =>
         CodegenError.singleton(s"Class ${name} could not be found")
       }
-    case TypeVariable(_, _) =>
+    case NamedTypeVariable(_, _) =>
+      Right(AsmType.getDescriptor(classOf[Object]))
+    case InferredTypeVariable(_, _) =>
       Right(AsmType.getDescriptor(classOf[Object]))
   }
 
@@ -236,7 +238,9 @@ class Codegen(verifyCodegen: Boolean) {
       }.leftFlatMap { _ =>
         CodegenError.singleton(s"Class ${name} could not be found")
       }
-    case TypeVariable(_, _) =>
+    case NamedTypeVariable(_, _) =>
+      Right(AsmType.getType(classOf[Object]))
+    case InferredTypeVariable(_, _) =>
       Right(AsmType.getType(classOf[Object]))
   }
 
@@ -265,7 +269,9 @@ class Codegen(verifyCodegen: Boolean) {
       }.leftFlatMap { _ =>
         CodegenError.singleton(s"Class ${name} could not be found")
       }
-    case TypeVariable(_, _) =>
+    case NamedTypeVariable(_, _) =>
+      Right(AsmType.getType(classOf[Object]))
+    case InferredTypeVariable(_, _) =>
       Right(AsmType.getType(classOf[Object]))
   }
 

--- a/common/src/inc/common/Constraint.scala
+++ b/common/src/inc/common/Constraint.scala
@@ -3,11 +3,14 @@ package inc.common
 import scala.{ Product, Serializable }
 import scala.collection.immutable.Map
 
-sealed trait Constraint extends Product with Serializable {
+sealed abstract class Constraint extends Product with Serializable {
   def pos: Pos
-  def substitute(subst: Map[TypeVariable, Type]): Constraint = this match {
-    case Equal(l, r, pos) => Equal(l.substitute(subst), r.substitute(subst), pos)
-  }
+  def substitute(subst: Map[TypeVariable, Type]): Constraint =
+    if (subst.isEmpty)
+      this
+    else this match {
+      case Equal(l, r, pos) => Equal(l.substitute(subst), r.substitute(subst), pos)
+    }
 }
 
 case class Equal(l: Type, r: Type, pos: Pos) extends Constraint

--- a/common/src/inc/common/Expr.scala
+++ b/common/src/inc/common/Expr.scala
@@ -7,7 +7,7 @@ import scala.{ =:=, Boolean, Char, Double, Float, Int, Long, Product, Serializab
 import scala.collection.immutable.{ List, Map, Set }
 import scala.Predef.wrapRefArray
 
-sealed trait Expr[A] extends Product with Serializable {
+sealed abstract class Expr[A] extends Product with Serializable {
   def meta: A
 
   def capturedVariables(implicit eqv: A =:= NamePosType): Set[Reference[NamePosType]] = this match {
@@ -108,8 +108,12 @@ sealed trait Expr[A] extends Product with Serializable {
   }
 
   def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): Expr[A] = {
-    val from = to.flip
-    this.map(a => from(to(a).substitute(subst)))
+    if (subst.isEmpty)
+      this
+    else {
+      val from = to.flip
+      this.map(a => from(to(a).substitute(subst)))
+    }
   }
 }
 object Expr {

--- a/common/src/inc/common/Import.scala
+++ b/common/src/inc/common/Import.scala
@@ -1,10 +1,10 @@
 package inc.common
 
 import java.lang.String
-import scala.{ Some, None }
+import scala.{ Some, None, Product, Serializable }
 import scala.collection.immutable.List
 
-sealed trait Import {
+sealed abstract class Import extends Product with Serializable {
   val pos: Pos
   def moduleName: String = this match {
     case ImportModule(pkg, name, _) => pkg.mkString("/") + "/" + name

--- a/common/src/inc/common/Kind.scala
+++ b/common/src/inc/common/Kind.scala
@@ -3,17 +3,20 @@ package inc.common
 import java.lang.Exception
 import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.immutable.{ List, Map }
-import scala.Int
+import scala.{ Int, Product, Serializable }
 
-sealed trait Kind {
-  def substitute(subst: Map[KindVariable, Kind]): Kind = this match {
-    case Atomic =>
-      Atomic
-    case kindVar @ KindVariable(_) =>
-      subst.getOrElse(kindVar, kindVar)
-    case Parameterized(params, result) =>
-      Parameterized(params.map(_.substitute(subst)), result.substitute(subst))
-  }
+sealed abstract class Kind extends Product with Serializable {
+  def substitute(subst: Map[KindVariable, Kind]): Kind =
+    if (subst.isEmpty)
+      this
+    else this match {
+      case Atomic =>
+        Atomic
+      case kindVar @ KindVariable(_) =>
+        subst.getOrElse(kindVar, kindVar)
+      case Parameterized(params, result) =>
+        Parameterized(params.map(_.substitute(subst)), result.substitute(subst))
+    }
 
   def toProto: proto.Kind = this match {
     case Atomic =>

--- a/common/src/inc/common/KindConstraint.scala
+++ b/common/src/inc/common/KindConstraint.scala
@@ -3,11 +3,14 @@ package inc.common
 import scala.{ Product, Serializable }
 import scala.collection.immutable.Map
 
-sealed trait KindConstraint extends Product with Serializable {
+sealed abstract class KindConstraint extends Product with Serializable {
   def pos: Pos
-  def substitute(subst: Map[KindVariable, Kind]): KindConstraint = this match {
-    case EqualKind(l, r, pos) => EqualKind(l.substitute(subst), r.substitute(subst), pos)
-  }
+  def substitute(subst: Map[KindVariable, Kind]): KindConstraint =
+    if (subst.isEmpty)
+      this
+    else this match {
+      case EqualKind(l, r, pos) => EqualKind(l.substitute(subst), r.substitute(subst), pos)
+    }
 }
 
 case class EqualKind(l: Kind, r: Kind, pos: Pos) extends KindConstraint

--- a/common/src/inc/common/Meta.scala
+++ b/common/src/inc/common/Meta.scala
@@ -15,7 +15,10 @@ case class NameWithType(name: Name, typ: TypeScheme) {
     NamePosType(name, Pos.Empty, typ)
 
   def substitute(subst: Map[TypeVariable, Type]): NameWithType =
-    copy(typ = typ.substitute(subst))
+    if (subst.isEmpty)
+      this
+    else
+      copy(typ = typ.substitute(subst))
 }
 
 object NameWithType {
@@ -37,5 +40,8 @@ case class NamePosType(name: Name, pos: Pos, typ: TypeScheme) {
   def forgetPos = NameWithType(name, typ)
 
   def substitute(subst: Map[TypeVariable, Type]): NamePosType =
-    copy(typ = typ.substitute(subst))
+    if (subst.isEmpty)
+      this
+    else
+      copy(typ = typ.substitute(subst))
 }

--- a/common/src/inc/common/Module.scala
+++ b/common/src/inc/common/Module.scala
@@ -24,10 +24,13 @@ final case class Module[A](
 
   def fullName = (pkg :+ name).mkString("/")
 
-  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): Module[A] = {
-    val from = to.flip
-    this.map(a => from(to(a).substitute(subst)))
-  }
+  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): Module[A] =
+    if (subst.isEmpty)
+      this
+    else {
+      val from = to.flip
+      this.map(a => from(to(a).substitute(subst)))
+    }
 }
 
 object Module {

--- a/common/src/inc/common/Name.scala
+++ b/common/src/inc/common/Name.scala
@@ -2,8 +2,9 @@ package inc.common
 
 import java.lang.{ Exception, String }
 import scala.collection.immutable.List
+import scala.{ Product, Serializable }
 
-sealed trait Name {
+sealed abstract class Name extends Product with Serializable {
   def toProto: proto.Name = this match {
     case NoName => proto.NoName()
     case LocalName(nm) => proto.LocalName(nm)

--- a/common/src/inc/common/Param.scala
+++ b/common/src/inc/common/Param.scala
@@ -8,8 +8,12 @@ import scala.collection.immutable.Map
 
 final case class Param[A](name: String, ascribedAs: Option[TypeScheme], meta: A) {
   def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType) = {
-    val from = to.flip
-    Param(name, ascribedAs, from(to(meta).substitute(subst)))
+    if (subst.isEmpty)
+      this
+    else {
+      val from = to.flip
+      Param(name, ascribedAs, from(to(meta).substitute(subst)))
+    }
   }
 
   def withAscribedType(implicit eqv: A =:= NameWithPos): Param[NamePosType] =

--- a/common/src/inc/common/Printer.scala
+++ b/common/src/inc/common/Printer.scala
@@ -57,7 +57,9 @@ object Printer {
   }
 
   def print(typ: Type): Doc = typ match {
-    case TypeVariable(i, _) =>
+    case NamedTypeVariable(n, _) =>
+      Doc.text(n)
+    case InferredTypeVariable(i, _) =>
       Doc.text("T" + i.toString)
     case TypeConstructor(nm, _) =>
       Doc.text(nm)

--- a/common/src/inc/common/TopLevelDeclaration.scala
+++ b/common/src/inc/common/TopLevelDeclaration.scala
@@ -7,7 +7,7 @@ import scala.{ Product, Serializable, Some }
 import scala.=:=
 import scala.collection.immutable.Map
 
-sealed trait TopLevelDeclaration[A] extends Product with Serializable {
+sealed abstract class TopLevelDeclaration[A] extends Product with Serializable {
   def name: String
 
   def meta: A
@@ -18,10 +18,13 @@ sealed trait TopLevelDeclaration[A] extends Product with Serializable {
       proto.Let(name, expr.toProto, nameWithType)
   }
 
-  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): TopLevelDeclaration[A] = {
-    val from = to.flip
-    this.map(a => from(to(a).substitute(subst)))
-  }
+  def substitute(subst: Map[TypeVariable, Type])(implicit to: A =:= NamePosType): TopLevelDeclaration[A] =
+    if (subst.isEmpty)
+      this
+    else {
+      val from = to.flip
+      this.map(a => from(to(a).substitute(subst)))
+    }
 }
 
 object TopLevelDeclaration {

--- a/proto/protobuf/ast.proto
+++ b/proto/protobuf/ast.proto
@@ -31,7 +31,12 @@ message Kind {
   }
 }
 
-message TypeVariable {
+message NamedTypeVariable {
+  string name = 1;
+  Kind kind = 2;
+}
+
+message InferredTypeVariable {
   int32 id = 1;
   Kind kind = 2;
 }
@@ -44,6 +49,13 @@ message TypeConstructor {
 message TypeApply {
   Type typ = 1;
   repeated Type params = 2;
+}
+
+message TypeVariable {
+  oneof tyVar {
+    NamedTypeVariable named = 1;
+    InferredTypeVariable inferred = 2;
+  }
 }
 
 message Type {
@@ -143,8 +155,8 @@ message If {
 
 message Param {
   string name = 1;
-  TypeScheme ascribedAs = 3;
-  NameWithType nameWithType = 2;
+  TypeScheme ascribedAs = 2;
+  NameWithType nameWithType = 3;
 }
 
 message Lambda {
@@ -167,19 +179,19 @@ message Ascription {
 
 message Expr {
   oneof sealed_value {
-    Reference ref = 2;
-    LiteralInt int = 3;
-    LiteralLong long = 4;
-    LiteralFloat flt = 5;
-    LiteralDouble dbl = 6; 
-    LiteralBoolean boolean = 7;
-    LiteralString str = 8;
-    LiteralChar char = 9;
-    LiteralUnit unit = 10;
-    If if = 11;
-    Lambda lambda = 12;
-    Apply apply = 13;
-    Ascription ascription = 14;
+    Reference ref = 1;
+    LiteralInt int = 2;
+    LiteralLong long = 3;
+    LiteralFloat flt = 4;
+    LiteralDouble dbl = 5; 
+    LiteralBoolean boolean = 6;
+    LiteralString str = 7;
+    LiteralChar char = 8;
+    LiteralUnit unit = 9;
+    If if = 10;
+    Lambda lambda = 11;
+    Apply apply = 12;
+    Ascription ascription = 13;
   }
 }
 

--- a/typechecker/src/inc/typechecker/Solve.scala
+++ b/typechecker/src/inc/typechecker/Solve.scala
@@ -26,7 +26,9 @@ class Solve(context: Printer.SourceContext, isTraceEnabled: Boolean) extends Laz
 
   def bind(pos: Pos, tyVar: TypeVariable, typ: Type): Infer[Substitution] =
     typ match {
-      case t @ TypeVariable(_, _) if tyVar == t =>
+      case t @ InferredTypeVariable(_, _) if tyVar == t =>
+        Right(EmptySubst)
+      case t @ NamedTypeVariable(_, _) if tyVar == t =>
         Right(EmptySubst)
       case t if tyVar.occursIn(t) =>
         TypeError.singleton(pos, "Attempt to construct infinite type")
@@ -69,10 +71,16 @@ class Solve(context: Printer.SourceContext, isTraceEnabled: Boolean) extends Laz
         case (TypeConstructor(l, _), TypeConstructor(r, _)) if l == r =>
           Right(EmptySubst)
 
-        case (tyVar @ TypeVariable(_, _), typ) =>
+        case (tyVar @ InferredTypeVariable(_, _), typ) =>
           bind(pos, tyVar, typ)
 
-        case (typ, tyVar @ TypeVariable(_, _)) =>
+        case (typ, tyVar @ InferredTypeVariable(_, _)) =>
+          bind(pos, tyVar, typ)
+
+        case (tyVar @ NamedTypeVariable(_, _), typ) =>
+          bind(pos, tyVar, typ)
+
+        case (typ, tyVar @ NamedTypeVariable(_, _)) =>
           bind(pos, tyVar, typ)
 
         case (_, _) =>


### PR DESCRIPTION
Another change to support #23 - we need to distinguish between named type variables and synthetic / inferred type variables to allow type variables introduced by data types to be referred to in ascriptions and appear in error messages.