### PR TITLE
Add JDK17 to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
We should build every LTS